### PR TITLE
Merge

### DIFF
--- a/chia/cmds/farm.py
+++ b/chia/cmds/farm.py
@@ -50,31 +50,56 @@ def farm_cmd() -> None:
     show_default=True,
 )
 @click.option(
-    "-sd",
-    "--staking-detail",
+    "-sa",
+    "--staking-addresses",
     help=(
         """\b
-        Set the level of detail to display for staking information.
-        Higher detail levels will make this command run slower.
-        0 - Don't show staking information (default).
-        1 - Show staking addresses.
-        2 - Show staking addresses plus staked coins per address.
-        3 - Show staking addresses plus staked coins and plot count per address."""
+        Fetch staking addresses and cache them to
+        always be shown when running 'farm summary'.
+        You must rerun this command option when
+        adding/removing keys or plots to update the
+        cache, even across restarts.
+        
+        \b
+        n - Clear staking address cache.
+        k - Fetch staking addresses from keys. Does
+            not show plot counts.
+        p - Fetch staking addresses from plots. Does
+            not show staking addresses for keys
+            without plots.
+        a - Fetch staking addresses from keys and
+            plots. Shows plot counts and addresses
+            for keys without plots."""
     ),
-    type=int,
-    default=0
+    type=str,
+    default=None,
+    show_default=True,
+)
+@click.option(
+    "-sb",
+    "--staking-balance",
+    help=(
+        """\b
+        Show the balance of each staking address.
+        Requires staking info to be cached by
+        -sa/--staking-addresses beforehand."""
+    ),
+    is_flag=True,
+    type=bool,
+    default=False
 )
 def summary_cmd(
     rpc_port: Optional[int],
     wallet_rpc_port: Optional[int],
     harvester_rpc_port: Optional[int],
     farmer_rpc_port: Optional[int],
-    staking_detail: Optional[int],
+    staking_addresses: Optional[str],
+    staking_balance: Optional[bool],
 ) -> None:
     from .farm_funcs import summary
     import asyncio
 
-    asyncio.run(summary(rpc_port, wallet_rpc_port, harvester_rpc_port, farmer_rpc_port, staking_detail))
+    asyncio.run(summary(rpc_port, wallet_rpc_port, harvester_rpc_port, farmer_rpc_port, staking_addresses, staking_balance))
 
 
 @farm_cmd.command("challenges", short_help="Show the latest challenges")

--- a/chia/cmds/farm.py
+++ b/chia/cmds/farm.py
@@ -49,44 +49,16 @@ def farm_cmd() -> None:
     default=None,
     show_default=True,
 )
-@click.option(
-    "-sd",
-    "--staking-detail",
-    help=(
-        """\b
-        Fetch a specific selection of staking
-        information. Everything except for balances
-        will be cached, and this cache will only be
-        used when 'k' and 'p' aren't specified.
-        
-        \b
-        Specify more than one of the following letters:
-        n - Clear cache and don't show staking information.
-        k - Fetch staking addresses from keys. Does
-            not show plot counts.
-        p - Fetch staking addresses from plots. Does
-            not show staking addresses for keys
-            without plots.
-        b - Fetch staking balances from listed addresses.
-        
-        \b
-        The default selection is "kpb"."""
-    ),
-    type=str,
-    default="kpb",
-    show_default=False,
-)
 def summary_cmd(
     rpc_port: Optional[int],
     wallet_rpc_port: Optional[int],
     harvester_rpc_port: Optional[int],
     farmer_rpc_port: Optional[int],
-    staking_detail: Optional[str],
 ) -> None:
     from .farm_funcs import summary
     import asyncio
 
-    asyncio.run(summary(rpc_port, wallet_rpc_port, harvester_rpc_port, farmer_rpc_port, staking_detail))
+    asyncio.run(summary(rpc_port, wallet_rpc_port, harvester_rpc_port, farmer_rpc_port))
 
 
 @farm_cmd.command("challenges", short_help="Show the latest challenges")

--- a/chia/cmds/farm.py
+++ b/chia/cmds/farm.py
@@ -50,56 +50,43 @@ def farm_cmd() -> None:
     show_default=True,
 )
 @click.option(
-    "-sa",
-    "--staking-addresses",
+    "-sd",
+    "--staking-detail",
     help=(
         """\b
-        Fetch staking addresses and cache them to
-        always be shown when running 'farm summary'.
-        You must rerun this command option when
-        adding/removing keys or plots to update the
-        cache, even across restarts.
+        Fetch a specific selection of staking
+        information. Everything except for balances
+        will be cached, and this cache will only be
+        used when 'k' and 'p' aren't specified.
         
         \b
-        n - Clear staking address cache.
+        Specify more than one of the following letters:
+        n - Clear cache and don't show staking information.
         k - Fetch staking addresses from keys. Does
             not show plot counts.
         p - Fetch staking addresses from plots. Does
             not show staking addresses for keys
             without plots.
-        a - Fetch staking addresses from keys and
-            plots. Shows plot counts and addresses
-            for keys without plots."""
+        b - Fetch staking balances from listed addresses.
+        
+        \b
+        The default selection is "kpb"."""
     ),
     type=str,
-    default=None,
-    show_default=True,
-)
-@click.option(
-    "-sb",
-    "--staking-balance",
-    help=(
-        """\b
-        Show the balance of each staking address.
-        Requires staking info to be cached by
-        -sa/--staking-addresses beforehand."""
-    ),
-    is_flag=True,
-    type=bool,
-    default=False
+    default="kpb",
+    show_default=False,
 )
 def summary_cmd(
     rpc_port: Optional[int],
     wallet_rpc_port: Optional[int],
     harvester_rpc_port: Optional[int],
     farmer_rpc_port: Optional[int],
-    staking_addresses: Optional[str],
-    staking_balance: Optional[bool],
+    staking_detail: Optional[str],
 ) -> None:
     from .farm_funcs import summary
     import asyncio
 
-    asyncio.run(summary(rpc_port, wallet_rpc_port, harvester_rpc_port, farmer_rpc_port, staking_addresses, staking_balance))
+    asyncio.run(summary(rpc_port, wallet_rpc_port, harvester_rpc_port, farmer_rpc_port, staking_detail))
 
 
 @farm_cmd.command("challenges", short_help="Show the latest challenges")

--- a/chia/cmds/farm.py
+++ b/chia/cmds/farm.py
@@ -49,16 +49,32 @@ def farm_cmd() -> None:
     default=None,
     show_default=True,
 )
+@click.option(
+    "-sd",
+    "--staking-detail",
+    help=(
+        """\b
+        Set the level of detail to display for staking information.
+        Higher detail levels will make this command run slower.
+        0 - Don't show staking information (default).
+        1 - Show staking addresses.
+        2 - Show staking addresses plus staked coins per address.
+        3 - Show staking addresses plus staked coins and plot count per address."""
+    ),
+    type=int,
+    default=0
+)
 def summary_cmd(
     rpc_port: Optional[int],
     wallet_rpc_port: Optional[int],
     harvester_rpc_port: Optional[int],
     farmer_rpc_port: Optional[int],
+    staking_detail: Optional[int],
 ) -> None:
     from .farm_funcs import summary
     import asyncio
 
-    asyncio.run(summary(rpc_port, wallet_rpc_port, harvester_rpc_port, farmer_rpc_port))
+    asyncio.run(summary(rpc_port, wallet_rpc_port, harvester_rpc_port, farmer_rpc_port, staking_detail))
 
 
 @farm_cmd.command("challenges", short_help="Show the latest challenges")

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -357,7 +357,7 @@ async def summary(
         print(format_bytes(int(est_plot_size)))
 
         sf = PlotStats.total_plot_size / est_plot_size
-        print(f"Estimated effecitve staking factor: {sf:.2f}")
+        print(f"Estimated effecitve staking factor: {round(sf, 2)}")
 
         print("Expected time to win: " + format_minutes(minutes))
 

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -356,6 +356,9 @@ async def summary(
         print("Estimated effective farm capacity: ", end="")
         print(format_bytes(int(est_plot_size)))
 
+        sf = PlotStats.total_plot_size / est_plot_size
+        print(f"Estimated effecitve staking factor: {sf:.2f}")
+
         print("Expected time to win: " + format_minutes(minutes))
 
     if amounts is None:

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -337,7 +337,7 @@ async def summary(
         print("Total size of plots: Unknown")
 
     if blockchain_state is not None:
-        print("Estimated network space: ", end="")
+        print("Estimated effective network space: ", end="")
         print(format_bytes(blockchain_state["space"]))
     else:
         print("Estimated network space: Unknown")

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -13,7 +13,7 @@ from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
-from chia.util.config import load_config
+from chia.util.config import load_config, save_config, config_path_for_filename
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.ints import uint16, uint64
 from chia.util.misc import format_bytes, format_minutes
@@ -210,7 +210,8 @@ async def summary(
     wallet_rpc_port: Optional[int],
     harvester_rpc_port: Optional[int],
     farmer_rpc_port: Optional[int],
-    staking_detail: Optional[int],
+    fetch_staking_addresses: Optional[str],
+    show_staking_balance: Optional[bool],
 ) -> None:
     config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     all_harvesters = await get_harvesters(farmer_rpc_port)
@@ -250,6 +251,7 @@ async def summary(
         total_plot_size = 0
         total_plots = 0
         staking_addresses = defaultdict(int)
+        fingerprints = defaultdict(int)
 
     if all_harvesters is not None:
         harvesters_local: dict = {}
@@ -264,21 +266,46 @@ async def summary(
                 harvesters_remote[ip][harvester["connection"]["node_id"]] = harvester
 
         def process_harvesters(harvester_peers_in: dict):
-            if staking_detail >= 1:
+            if get_staking_addresses_from_keys:
                 keychain = Keychain()
                 private_keys = keychain.get_all_private_keys()
+
                 for sk, seed in private_keys:
                     ph = create_puzzlehash_for_pk(hexstr_to_bytes(str(master_sk_to_farmer_sk(sk).get_g1())))
+
                     PlotStats.staking_addresses[ph] += 0
+                    PlotStats.fingerprints[str(ph)] = sk.get_g1().get_fingerprint()
+
             for harvester_peer_id, plots in harvester_peers_in.items():
                 total_plot_size_harvester = sum(map(lambda x: x["file_size"], plots["plots"]))
                 PlotStats.total_plot_size += total_plot_size_harvester
                 PlotStats.total_plots += len(plots["plots"])
-                if staking_detail >= 3:
+                if get_staking_addresses_from_plots:
                     for plot in plots["plots"]:
                         ph = create_puzzlehash_for_pk(hexstr_to_bytes(plot["farmer_public_key"]))
                         PlotStats.staking_addresses[ph] += 1
                 print(f"   {len(plots['plots'])} plots of size: {format_bytes(total_plot_size_harvester)}")
+
+        STAKING_INFO_CACHE_FILE = 'staking_info_cache.yaml'
+        staking_info_cache_path = config_path_for_filename(DEFAULT_ROOT_PATH, STAKING_INFO_CACHE_FILE)
+
+        get_staking_addresses_from_keys = False
+        get_staking_addresses_from_plots = False
+        invalid_sa_option = False
+
+        if fetch_staking_addresses == 'k':
+            get_staking_addresses_from_keys = True
+        elif fetch_staking_addresses == 'p':
+            get_staking_addresses_from_plots = True
+        elif fetch_staking_addresses == 'a':
+            get_staking_addresses_from_keys = True
+            get_staking_addresses_from_plots = True
+        elif fetch_staking_addresses == 'n':
+
+            if staking_info_cache_path.exists():
+                staking_info_cache_path.unlink()
+        elif fetch_staking_addresses != None:
+            invalid_sa_option = True
 
         if len(harvesters_local) > 0:
             print(f"Local Harvester{'s' if len(harvesters_local) > 1 else ''}")
@@ -292,25 +319,47 @@ async def summary(
         print("Total size of plots: ", end="")
         print(format_bytes(PlotStats.total_plot_size))
 
-        if staking_detail >= 0 and staking_detail <= 3:
-            if staking_detail > 0:
-                print("Staking addresses:")
-            address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
-            for k, v in sorted(PlotStats.staking_addresses.items(), key=(lambda tup: tup[1]), reverse=True):
-                ph = encode_puzzle_hash(k, address_prefix)
-                balance = None
-                if staking_detail >= 2:
-                    # query balance
-                    balance = await get_ph_balance(rpc_port, k)
-                    balance /= Decimal(10 ** 12)
-                if staking_detail == 1:
-                    print(f"  {ph}")
-                elif staking_detail == 2:
-                    print(f"  {ph} (balance: {balance})")
-                elif staking_detail == 3:
-                    print(f"  {ph} (balance: {balance}, plots: {v})")
+        staking_info = None
+
+        if get_staking_addresses_from_keys or get_staking_addresses_from_plots:
+            staking_info = {}
+
+            for ph, plots in PlotStats.staking_addresses.items():
+                ph = str(ph)
+                staking_info[ph] = {}
+
+                if get_staking_addresses_from_keys:
+                    staking_info[ph]["fingerprint"] = PlotStats.fingerprints[ph]
+
+                if get_staking_addresses_from_plots:
+                    staking_info[ph]["plots"] = plots
+
+            save_config(DEFAULT_ROOT_PATH, STAKING_INFO_CACHE_FILE, staking_info)
+        elif staking_info_cache_path.exists():
+            staking_info = load_config(DEFAULT_ROOT_PATH, STAKING_INFO_CACHE_FILE)
+
+        if invalid_sa_option:
+            print(f"   Invalid argument for -sa/--staking-addresses: {fetch_staking_addresses}")
+
+        if staking_info == None:
+            if show_staking_balance:
+                print("   No staking addresses cached. See 'sit farm summary -h' for more info.")
         else:
-            print(f"   Unknown staking detail level {staking_detail}.")
+            print("Staking addresses:")
+            address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
+            for ph, entry in staking_info.items():
+                ph = hexstr_to_bytes(ph)
+                print(f"  {encode_puzzle_hash(ph, address_prefix)}")
+
+                if "fingerprint" in entry:
+                    print(f"    Fingerprint: {entry['fingerprint']}")
+                if "plots" in entry:
+                    print(f"    Plots: {entry['plots']}")
+                if show_staking_balance:
+                    # query balance
+                    balance = await get_ph_balance(rpc_port, ph)
+                    balance /= Decimal(10 ** 12)
+                    print(f"    Balance: {balance}")
     else:
         print("Plot count: Unknown")
         print("Total size of plots: Unknown")
@@ -340,10 +389,6 @@ async def summary(
             print("For details on farmed rewards and fees you should run 'sit wallet show'")
     else:
         print("Note: log into your key using 'sit wallet show' to see rewards for each key")
-    
-    if staking_detail == 0:
-        print("For details on staking you should run 'sit farm summary -sd 1'")
-    elif staking_detail == 1:
-        print("For number of coins staked per address you should run 'sit farm summary -sd 2'")
-    elif staking_detail == 2:
-        print("For number of plots per address you should run 'sit farm summary -sd 3'")
+
+    if fetch_staking_addresses == None and not show_staking_balance:
+        print("For details on staking you should run 'sit farm summary -h'")

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -318,7 +318,10 @@ async def summary(
             print(f"  {encode_puzzle_hash(ph, address_prefix)}")
 
             print(f"    Fingerprint: {PlotStats.fingerprints[ph]}")
-            print(f"    Plots: {plot_count}")
+
+            print(f"    Plots: {plot_count} (", end="")
+            print(format_bytes(PlotStats.capacities[ph]), end="")
+            print(")")
 
             # query balance
             balance = await get_ph_balance(rpc_port, ph)

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
-from datetime import datetime
 
 import aiohttp
 
@@ -14,7 +13,7 @@ from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
-from chia.util.config import load_config, save_config, config_path_for_filename
+from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.ints import uint16, uint64
 from chia.util.misc import format_bytes, format_minutes
@@ -211,7 +210,6 @@ async def summary(
     wallet_rpc_port: Optional[int],
     harvester_rpc_port: Optional[int],
     farmer_rpc_port: Optional[int],
-    staking_details: Optional[str],
 ) -> None:
     config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     all_harvesters = await get_harvesters(farmer_rpc_port)
@@ -252,6 +250,8 @@ async def summary(
         total_plots = 0
         staking_addresses = defaultdict(int)
         fingerprints = defaultdict(int)
+        capacities = defaultdict(int)
+        staking_factors = defaultdict(int)
 
     total_staking_balance = 0
     if all_harvesters is not None:
@@ -267,61 +267,38 @@ async def summary(
                 harvesters_remote[ip][harvester["connection"]["node_id"]] = harvester
 
         def process_harvesters(harvester_peers_in: dict):
-            if get_staking_addresses_from_keys:
-                keychain = Keychain()
-                private_keys = keychain.get_all_private_keys()
+            keychain = Keychain()
+            private_keys = keychain.get_all_private_keys()
 
-                for sk, seed in private_keys:
-                    ph = create_puzzlehash_for_pk(hexstr_to_bytes(str(master_sk_to_farmer_sk(sk).get_g1())))
+            for sk, seed in private_keys:
+                ph = create_puzzlehash_for_pk(hexstr_to_bytes(str(master_sk_to_farmer_sk(sk).get_g1())))
 
-                    PlotStats.staking_addresses[ph] += 0
-                    PlotStats.fingerprints[ph] = sk.get_g1().get_fingerprint()
+                PlotStats.staking_addresses[ph] += 0
+                PlotStats.fingerprints[ph] = sk.get_g1().get_fingerprint()
 
             for harvester_peer_id, plots in harvester_peers_in.items():
-                total_plot_size_harvester = sum(map(lambda x: x["file_size"], plots["plots"]))
-                PlotStats.total_plot_size += total_plot_size_harvester
+                total_plot_size_harvester = 0
                 PlotStats.total_plots += len(plots["plots"])
-                if get_staking_addresses_from_plots:
-                    farmer_public_keys = defaultdict(int)
 
-                    for plot in plots["plots"]:
-                        farmer_public_key = plot["farmer_public_key"]
-                        farmer_public_keys[farmer_public_key] += 1
+                plot_counts = defaultdict(int)
+                capacities = defaultdict(int)
 
-                    for farmer_public_key, plot_count in farmer_public_keys.items():
-                        ph = create_puzzlehash_for_pk(hexstr_to_bytes(farmer_public_key))
-                        PlotStats.staking_addresses[ph] += plot_count
+                for plot in plots["plots"]:
+                    farmer_public_key = plot["farmer_public_key"]
+                    plot_counts[farmer_public_key] += 1
+                    capacities[farmer_public_key] += plot["file_size"]
+
+                for farmer_public_key, plot_count in plot_counts.items():
+                    ph = create_puzzlehash_for_pk(hexstr_to_bytes(farmer_public_key))
+
+                    PlotStats.staking_addresses[ph] += plot_counts[farmer_public_key]
+
+                    capacity = capacities[farmer_public_key]
+                    PlotStats.capacities[ph] += capacity
+                    total_plot_size_harvester += capacity
+
+                PlotStats.total_plot_size += total_plot_size_harvester
                 print(f"   {len(plots['plots'])} plots of size: {format_bytes(total_plot_size_harvester)}")
-
-        STAKING_INFO_CACHE_FILE = 'staking_info_cache.yaml'
-        staking_info_cache_path = config_path_for_filename(DEFAULT_ROOT_PATH, STAKING_INFO_CACHE_FILE)
-
-        get_staking_addresses_from_keys = False
-        get_staking_addresses_from_plots = False
-        get_staking_balances = False
-        invalid_options = ""
-        notices = []
-        
-        invalid_options_dict = defaultdict(bool)
-
-        for option in list(staking_details):
-            if option == 'k':
-                get_staking_addresses_from_keys = True
-            elif option == 'p':
-                get_staking_addresses_from_plots = True
-            elif option == 'n':
-                if staking_info_cache_path.exists():
-                    staking_info_cache_path.unlink()
-            elif option == 'b':
-                get_staking_balances = True
-            else:
-                invalid_options_dict[option] = True
-
-        if invalid_options_dict:
-            for option, _ in invalid_options_dict.items():
-                invalid_options += option
-
-            notices.append(f"    Invalid staking detail options: {invalid_options}")
 
         if len(harvesters_local) > 0:
             print(f"Local Harvester{'s' if len(harvesters_local) > 1 else ''}")
@@ -335,67 +312,23 @@ async def summary(
         print("Total size of plots: ", end="")
         print(format_bytes(PlotStats.total_plot_size))
 
-        staking_info = None
+        print("Staking addresses:")
+        address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
+        for ph, plot_count in PlotStats.staking_addresses.items():
+            print(f"  {encode_puzzle_hash(ph, address_prefix)}")
 
-        if get_staking_addresses_from_keys or get_staking_addresses_from_plots:
-            staking_info = {}
+            print(f"    Fingerprint: {PlotStats.fingerprints[ph]}")
+            print(f"    Plots: {plot_count}")
 
-            for ph, plots in PlotStats.staking_addresses.items():
-                ph_str = str(ph)
-                staking_info[ph_str] = {}
+            # query balance
+            balance = await get_ph_balance(rpc_port, ph)
+            balance /= Decimal(10 ** 12)
 
-                if get_staking_addresses_from_keys:
-                    staking_info[ph_str]["fingerprint"] = PlotStats.fingerprints[ph]
+            sf = await get_est_staking_factor(PlotStats.capacities[ph], balance)
+            PlotStats.staking_factors[ph] = sf
 
-                if get_staking_addresses_from_plots:
-                    staking_info[ph_str]["plots"] = plots
-
-            save_config(DEFAULT_ROOT_PATH, STAKING_INFO_CACHE_FILE, staking_info)
-        elif staking_info_cache_path.exists():
-            staking_info = load_config(DEFAULT_ROOT_PATH, STAKING_INFO_CACHE_FILE)
-
-            cache_timestamp = staking_info_cache_path.stat().st_mtime
-            cache_datetime = datetime.fromtimestamp(cache_timestamp).strftime("%Y-%m-%d %H:%M:%S")
-
-            notices.append(
-                 "    The following staking information, with the exception of balances,\n"
-                f"      is fetched from a cache last updated at {cache_datetime}."
-            )
-
-        def print_staking_header():
-            print("Staking addresses:")
-
-            if notices:
-                print("  Attention:")
-
-                for notice in notices:
-                    print(notice)
-
-        if staking_info == None:
-            if get_staking_balances or invalid_options:
-                if get_staking_balances:
-                    notices.append("    No staking addresses cached, you must fetch them to show staking balances.")
-
-                print_staking_header()
-        else:
-            print_staking_header()
-
-            address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
-            for ph, entry in staking_info.items():
-                ph = hexstr_to_bytes(ph)
-                print(f"  {encode_puzzle_hash(ph, address_prefix)}")
-
-                if "fingerprint" in entry:
-                    print(f"    Fingerprint: {entry['fingerprint']}")
-                if "plots" in entry:
-                    print(f"    Plots: {entry['plots']}")
-                if get_staking_balances:
-                    # query balance
-                    balance = await get_ph_balance(rpc_port, ph)
-                    balance /= Decimal(10 ** 12)
-                    total_staking_balance += balance
-
-                    print(f"    Balance: {balance} SIT")
+            print(f"    Balance: {balance} SIT")
+            print(f"    Estimated staking factor: {sf}")
     else:
         print("Plot count: Unknown")
         print("Total size of plots: Unknown")
@@ -406,12 +339,13 @@ async def summary(
     else:
         print("Estimated network space: Unknown")
 
-    sf = await get_est_staking_factor(PlotStats.total_plot_size, total_staking_balance)
-    print(f"Estimated staking factor: {sf}")
-
     minutes = -1
     if blockchain_state is not None and all_harvesters is not None:
-        est_plot_size = PlotStats.total_plot_size / float(sf)
+        est_plot_size = 0
+
+        for ph, capacity in PlotStats.capacities.items():
+            est_plot_size += capacity / float(PlotStats.staking_factors[ph])
+
         proportion = est_plot_size / blockchain_state["space"] if blockchain_state["space"] else -1
         minutes = int((await get_average_block_time(rpc_port) / 60) / proportion) if proportion else -1
 
@@ -438,7 +372,7 @@ async def get_est_staking_factor(total_plot_size, total_staking_balance) -> Deci
         return Decimal(1)
 
     # convert farmer space from byte to T unit
-    converted_plot_size = total_plot_size / 1000000000000
+    converted_plot_size = total_plot_size / 1099511627776
 
     if total_staking_balance >= converted_plot_size:
         sf = Decimal("0.5") + Decimal(1) / (Decimal(total_staking_balance) / Decimal(converted_plot_size) + Decimal(1))

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -293,7 +293,8 @@ async def summary(
         print(format_bytes(PlotStats.total_plot_size))
 
         if staking_detail >= 0 and staking_detail <= 3:
-            print("Staking addresses:")
+            if staking_detail > 0:
+                print("Staking addresses:")
             address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
             for k, v in sorted(PlotStats.staking_addresses.items(), key=(lambda tup: tup[1]), reverse=True):
                 ph = encode_puzzle_hash(k, address_prefix)

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -269,10 +269,10 @@ async def summary(
             if get_staking_addresses_from_keys:
                 keychain = Keychain()
                 private_keys = keychain.get_all_private_keys()
-                
+
                 for sk, seed in private_keys:
                     ph = create_puzzlehash_for_pk(hexstr_to_bytes(str(master_sk_to_farmer_sk(sk).get_g1())))
-                    
+
                     PlotStats.staking_addresses[ph] += 0
                     PlotStats.fingerprints[str(ph)] = sk.get_g1().get_fingerprint()
 
@@ -286,6 +286,9 @@ async def summary(
                         PlotStats.staking_addresses[ph] += 1
                 print(f"   {len(plots['plots'])} plots of size: {format_bytes(total_plot_size_harvester)}")
 
+        STAKING_INFO_CACHE_FILE = 'staking_info_cache.yaml'
+        staking_info_cache_path = config_path_for_filename(DEFAULT_ROOT_PATH, STAKING_INFO_CACHE_FILE)
+
         get_staking_addresses_from_keys = False
         get_staking_addresses_from_plots = False
         invalid_sa_option = False
@@ -298,13 +301,10 @@ async def summary(
             get_staking_addresses_from_keys = True
             get_staking_addresses_from_plots = True
         elif fetch_staking_addresses == 'n':
-            fetch_staking_addresses = None
-            
             if staking_info_cache_path.exists():
                 staking_info_cache_path.unlink()
         elif fetch_staking_addresses != None:
             invalid_sa_option = True
-            fetch_staking_addresses = None
 
         if len(harvesters_local) > 0:
             print(f"Local Harvester{'s' if len(harvesters_local) > 1 else ''}")
@@ -320,10 +320,7 @@ async def summary(
 
         staking_info = None
 
-        STAKING_INFO_CACHE_FILE = 'staking_info_cache.yaml'
-        staking_info_cache_path = config_path_for_filename(DEFAULT_ROOT_PATH, STAKING_INFO_CACHE_FILE)
-
-        if fetch_staking_addresses != None:
+        if get_staking_addresses_from_keys or get_staking_addresses_from_plots:
             staking_info = {}
 
             for ph, plots in PlotStats.staking_addresses.items():
@@ -391,6 +388,6 @@ async def summary(
             print("For details on farmed rewards and fees you should run 'sit wallet show'")
     else:
         print("Note: log into your key using 'sit wallet show' to see rewards for each key")
-    
-    if fetch_staking_addresses == None or not show_staking_balance:
+
+    if fetch_staking_addresses == None and not show_staking_balance:
         print("For details on staking you should run 'sit farm summary -h'")

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -253,7 +253,6 @@ async def summary(
         capacities = defaultdict(int)
         staking_factors = defaultdict(int)
 
-    total_staking_balance = 0
     if all_harvesters is not None:
         harvesters_local: dict = {}
         harvesters_remote: dict = {}

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -330,14 +330,14 @@ async def summary(
             staking_info = {}
 
             for ph, plots in PlotStats.staking_addresses.items():
-                ph = str(ph)
-                staking_info[ph] = {}
+                ph_str = str(ph)
+                staking_info[ph_str] = {}
 
                 if get_staking_addresses_from_keys:
-                    staking_info[ph]["fingerprint"] = PlotStats.fingerprints[ph]
+                    staking_info[ph_str]["fingerprint"] = PlotStats.fingerprints[ph]
 
                 if get_staking_addresses_from_plots:
-                    staking_info[ph]["plots"] = plots
+                    staking_info[ph_str]["plots"] = plots
 
             save_config(DEFAULT_ROOT_PATH, STAKING_INFO_CACHE_FILE, staking_info)
         elif staking_info_cache_path.exists():

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -340,7 +340,7 @@ async def summary(
         print("Estimated effective network space: ", end="")
         print(format_bytes(blockchain_state["space"]))
     else:
-        print("Estimated network space: Unknown")
+        print("Estimated effective network space: Unknown")
 
     minutes = -1
     est_plot_size = 0

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -269,10 +269,10 @@ async def summary(
             if get_staking_addresses_from_keys:
                 keychain = Keychain()
                 private_keys = keychain.get_all_private_keys()
-
+                
                 for sk, seed in private_keys:
                     ph = create_puzzlehash_for_pk(hexstr_to_bytes(str(master_sk_to_farmer_sk(sk).get_g1())))
-
+                    
                     PlotStats.staking_addresses[ph] += 0
                     PlotStats.fingerprints[str(ph)] = sk.get_g1().get_fingerprint()
 
@@ -286,9 +286,6 @@ async def summary(
                         PlotStats.staking_addresses[ph] += 1
                 print(f"   {len(plots['plots'])} plots of size: {format_bytes(total_plot_size_harvester)}")
 
-        STAKING_INFO_CACHE_FILE = 'staking_info_cache.yaml'
-        staking_info_cache_path = config_path_for_filename(DEFAULT_ROOT_PATH, STAKING_INFO_CACHE_FILE)
-
         get_staking_addresses_from_keys = False
         get_staking_addresses_from_plots = False
         invalid_sa_option = False
@@ -301,11 +298,13 @@ async def summary(
             get_staking_addresses_from_keys = True
             get_staking_addresses_from_plots = True
         elif fetch_staking_addresses == 'n':
-
+            fetch_staking_addresses = None
+            
             if staking_info_cache_path.exists():
                 staking_info_cache_path.unlink()
         elif fetch_staking_addresses != None:
             invalid_sa_option = True
+            fetch_staking_addresses = None
 
         if len(harvesters_local) > 0:
             print(f"Local Harvester{'s' if len(harvesters_local) > 1 else ''}")
@@ -321,7 +320,10 @@ async def summary(
 
         staking_info = None
 
-        if get_staking_addresses_from_keys or get_staking_addresses_from_plots:
+        STAKING_INFO_CACHE_FILE = 'staking_info_cache.yaml'
+        staking_info_cache_path = config_path_for_filename(DEFAULT_ROOT_PATH, STAKING_INFO_CACHE_FILE)
+
+        if fetch_staking_addresses != None:
             staking_info = {}
 
             for ph, plots in PlotStats.staking_addresses.items():
@@ -389,6 +391,6 @@ async def summary(
             print("For details on farmed rewards and fees you should run 'sit wallet show'")
     else:
         print("Note: log into your key using 'sit wallet show' to see rewards for each key")
-
-    if fetch_staking_addresses == None and not show_staking_balance:
+    
+    if fetch_staking_addresses == None or not show_staking_balance:
         print("For details on staking you should run 'sit farm summary -h'")

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -340,9 +340,8 @@ async def summary(
         print("Estimated network space: Unknown")
 
     minutes = -1
+    est_plot_size = 0
     if blockchain_state is not None and all_harvesters is not None:
-        est_plot_size = 0
-
         for ph, capacity in PlotStats.capacities.items():
             est_plot_size += capacity / float(PlotStats.staking_factors[ph])
 
@@ -352,6 +351,9 @@ async def summary(
     if all_harvesters is not None and PlotStats.total_plots == 0:
         print("Expected time to win: Never (no plots)")
     else:
+        print("Estimated effective farm capacity: ", end="")
+        print(format_bytes(int(est_plot_size)))
+
         print("Expected time to win: " + format_minutes(minutes))
 
     if amounts is None:

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -274,16 +274,22 @@ async def summary(
                     ph = create_puzzlehash_for_pk(hexstr_to_bytes(str(master_sk_to_farmer_sk(sk).get_g1())))
 
                     PlotStats.staking_addresses[ph] += 0
-                    PlotStats.fingerprints[str(ph)] = sk.get_g1().get_fingerprint()
+                    PlotStats.fingerprints[ph] = sk.get_g1().get_fingerprint()
 
             for harvester_peer_id, plots in harvester_peers_in.items():
                 total_plot_size_harvester = sum(map(lambda x: x["file_size"], plots["plots"]))
                 PlotStats.total_plot_size += total_plot_size_harvester
                 PlotStats.total_plots += len(plots["plots"])
                 if get_staking_addresses_from_plots:
+                    farmer_public_keys = defaultdict(int)
+
                     for plot in plots["plots"]:
-                        ph = create_puzzlehash_for_pk(hexstr_to_bytes(plot["farmer_public_key"]))
-                        PlotStats.staking_addresses[ph] += 1
+                        farmer_public_key = plot["farmer_public_key"]
+                        farmer_public_keys[farmer_public_key] += 1
+
+                    for farmer_public_key, plot_count in farmer_public_keys.items():
+                        ph = create_puzzlehash_for_pk(hexstr_to_bytes(farmer_public_key))
+                        PlotStats.staking_addresses[ph] += plot_count
                 print(f"   {len(plots['plots'])} plots of size: {format_bytes(total_plot_size_harvester)}")
 
         STAKING_INFO_CACHE_FILE = 'staking_info_cache.yaml'

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -353,16 +353,16 @@ def chia_init(
     protected Keychain. When launching the daemon from the GUI, we want the GUI to
     handle unlocking the keychain.
     """
-    if os.environ.get("CHIA_ROOT", None) is not None:
+    if os.environ.get("SIT_ROOT", None) is not None:
         print(
-            f"warning, your CHIA_ROOT is set to {os.environ['CHIA_ROOT']}. "
+            f"warning, your SIT_ROOT is set to {os.environ['SIT_ROOT']}. "
             f"Please unset the environment variable and run sit init again\n"
             f"or manually migrate config.yaml"
         )
 
     print(f"Silicoin directory {root_path}")
     if root_path.is_dir() and Path(root_path / "config" / "config.yaml").exists():
-        # This is reached if CHIA_ROOT is set, or if user has run sit init twice
+        # This is reached if SIT_ROOT is set, or if user has run sit init twice
         # before a new update.
         if testnet:
             configure(root_path, "", "", "", "", "", "", "", "", testnet="true", peer_connect_timeout="")

--- a/chia/cmds/plotnft.py
+++ b/chia/cmds/plotnft.py
@@ -11,7 +11,7 @@ def validate_fee(ctx, param, value):
     try:
         fee = Decimal(value)
     except ValueError:
-        raise click.BadParameter("Fee must be decimal dotted value in XCH (e.g. 0.00005)")
+        raise click.BadParameter("Fee must be decimal dotted value in SIT (e.g. 0.00005)")
     if fee < 0 or fee > MAX_CMDLINE_FEE:
         raise click.BadParameter(f"Fee must be in the range 0 to {MAX_CMDLINE_FEE}")
     return value
@@ -59,7 +59,7 @@ def get_login_link_cmd(launcher_id: str) -> None:
 @click.option(
     "-m",
     "--fee",
-    help="Set the fees per transaction, in XCH. Fee is used TWICE: once to create the singleton, once for init.",
+    help="Set the fees per transaction, in SIT. Fee is used TWICE: once to create the singleton, once for init.",
     type=str,
     default="0",
     show_default=True,
@@ -99,7 +99,7 @@ def create_cmd(
 @click.option(
     "-m",
     "--fee",
-    help="Set the fees per transaction, in XCH. Fee is used TWICE: once to leave pool, once to join.",
+    help="Set the fees per transaction, in SIT. Fee is used TWICE: once to leave pool, once to join.",
     type=str,
     default="0",
     show_default=True,
@@ -136,7 +136,7 @@ def join_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, fee: int
 @click.option(
     "-m",
     "--fee",
-    help="Set the fees per transaction, in XCH. Fee is charged TWICE.",
+    help="Set the fees per transaction, in SIT. Fee is charged TWICE.",
     type=str,
     default="0",
     show_default=True,
@@ -191,7 +191,7 @@ def inspect(wallet_rpc_port: Optional[int], fingerprint: int, id: int) -> None:
 @click.option(
     "-m",
     "--fee",
-    help="Set the fees per transaction, in XCH.",
+    help="Set the fees per transaction, in SIT.",
     type=str,
     default="0",
     show_default=True,

--- a/chia/cmds/show.py
+++ b/chia/cmds/show.py
@@ -81,7 +81,7 @@ async def show_async(
                     f"                 Height: {peak.height:>10}\n",
                 )
 
-                print("Estimated network space: ", end="")
+                print("Estimated effective network space: ", end="")
                 print(format_bytes(blockchain_state["space"]))
                 print(f"Current difficulty: {difficulty}")
                 print(f"Current VDF sub_slot_iters: {sub_slot_iters}")

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -123,7 +123,7 @@ def send_cmd(
     asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, send))
 
 
-@wallet_cmd.command("send_from", short_help="Transfer all sit away from a specific puzzle hash")
+@wallet_cmd.command("send_from", short_help="Transfer all Silicoin away from a specific puzzle hash")
 @click.option(
     "-p",
     "--rpc-port",

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -88,7 +88,7 @@ def get_transactions_cmd(
     sys.stdout.close()
 
 
-@wallet_cmd.command("send", short_help="Send sit to another wallet")
+@wallet_cmd.command("send", short_help="Send Silicoin to another wallet")
 @click.option(
     "-wp",
     "--wallet-rpc-port",

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -98,17 +98,17 @@ def get_transactions_cmd(
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
-@click.option("-a", "--amount", help="How much sit to send, in XCH", type=str, required=True)
+@click.option("-a", "--amount", help="How much sit to send, in SIT", type=str, required=True)
 @click.option(
     "-m",
     "--fee",
-    help="Set the fees for the transaction, in XCH",
+    help="Set the fees for the transaction, in SIT",
     type=str,
     default="0",
     show_default=True,
     required=True,
 )
-@click.option("-t", "--address", help="Address to send the XCH", type=str, required=True)
+@click.option("-t", "--address", help="Address to send the SIT", type=str, required=True)
 @click.option(
     "-o", "--override", help="Submits transaction without checking for unusual values", is_flag=True, default=False
 )
@@ -144,8 +144,8 @@ def send_cmd(
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
-@click.option("-s", "--source", help="Address to send the XCH from", type=str, required=True)
-@click.option("-t", "--address", help="Address to send the XCH", type=str, required=True)
+@click.option("-s", "--source", help="Address to send the SIT from", type=str, required=True)
+@click.option("-t", "--address", help="Address to send the SIT", type=str, required=True)
 def send_from_cmd(
     rpc_port: Optional[int],
     wallet_rpc_port: Optional[int],

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -259,7 +259,7 @@ async def do_recover_pool_nft(contract_hash: str, launcher_hash: str, fingerprin
 )
 @click.option(
     "--launcher-hash",
-    help="Set the launcher hash, you should get it from Silicoin wallet",
+    help="Set the launcher hash, you should get it from your Silicoin wallet",
     type=str,
     default=None,
 )

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -98,7 +98,7 @@ def get_transactions_cmd(
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
-@click.option("-a", "--amount", help="How much silicoin to send, in SIT", type=str, required=True)
+@click.option("-a", "--amount", help="How much Silicoin to send, in SIT", type=str, required=True)
 @click.option(
     "-m",
     "--fee",
@@ -259,7 +259,7 @@ async def do_recover_pool_nft(contract_hash: str, launcher_hash: str, fingerprin
 )
 @click.option(
     "--launcher-hash",
-    help="Set the launcher hash, you should get it from silicoin wallet",
+    help="Set the launcher hash, you should get it from Silicoin wallet",
     type=str,
     default=None,
 )

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -94,6 +94,20 @@ class Farmer:
         consensus_constants: ConsensusConstants,
         local_keychain: Optional[Keychain] = None,
     ):
+        pool_info_update_interval = UPDATE_POOL_INFO_INTERVAL
+        pool_farmer_info_update_interval = UPDATE_POOL_FARMER_INFO_INTERVAL
+        harvester_cache_update_interval = UPDATE_HARVESTER_CACHE_INTERVAL
+
+        if "update_intervals" in self.config:
+            update_intervals = self.config["update_intervals"]
+
+            if "pool_info" in update_intervals:
+                pool_info_update_interval = update_intervals["pool_info"]
+            if "pool_farmer_info" in update_intervals:
+                pool_farmer_info_update_interval = update_intervals["pool_farmer_info"]
+            if "harvester_cache" in update_intervals:
+                harvester_cache_update_interval = update_intervals["harvester_cache"]
+
         self.keychain_proxy: Optional[KeychainProxy] = None
         self.local_keychain = local_keychain
         self._root_path = root_path
@@ -116,7 +130,7 @@ class Farmer:
         self.cache_add_time: Dict[bytes32, uint64] = {}
 
         # Interval to request plots from connected harvesters
-        self.update_harvester_cache_interval = UPDATE_HARVESTER_CACHE_INTERVAL
+        self.update_harvester_cache_interval = harvester_cache_update_interval
 
         self.cache_clear_task: asyncio.Task
         self.update_pool_state_task: asyncio.Task
@@ -410,7 +424,7 @@ class Farmer:
                     pool_info = await self._pool_get_pool_info(pool_config)
                     if pool_info is not None and "error_code" not in pool_info:
                         pool_state["authentication_token_timeout"] = pool_info["authentication_token_timeout"]
-                        pool_state["next_pool_info_update"] = time.time() + UPDATE_POOL_INFO_INTERVAL
+                        pool_state["next_pool_info_update"] = time.time() + pool_info_update_interval
                         # Only update the first time from GET /pool_info, gets updated from GET /farmer later
                         if pool_state["current_difficulty"] is None:
                             pool_state["current_difficulty"] = pool_info["minimum_difficulty"]
@@ -431,7 +445,7 @@ class Farmer:
                                 if farmer_response is not None:
                                     pool_state["current_difficulty"] = farmer_response.current_difficulty
                                     pool_state["current_points"] = farmer_response.current_points
-                                    pool_state["next_farmer_update"] = time.time() + UPDATE_POOL_FARMER_INFO_INTERVAL
+                                    pool_state["next_farmer_update"] = time.time() + pool_farmer_info_update_interval
                             else:
                                 farmer_known = response["error_code"] != PoolErrorCode.FARMER_NOT_KNOWN.value
                                 self.log.error(

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -424,7 +424,7 @@ class Farmer:
                     pool_info = await self._pool_get_pool_info(pool_config)
                     if pool_info is not None and "error_code" not in pool_info:
                         pool_state["authentication_token_timeout"] = pool_info["authentication_token_timeout"]
-                        pool_state["next_pool_info_update"] = time.time() + pool_info_update_interval
+                        pool_state["next_pool_info_update"] = time.time() + self.pool_info_update_interval
                         # Only update the first time from GET /pool_info, gets updated from GET /farmer later
                         if pool_state["current_difficulty"] is None:
                             pool_state["current_difficulty"] = pool_info["minimum_difficulty"]
@@ -445,7 +445,7 @@ class Farmer:
                                 if farmer_response is not None:
                                     pool_state["current_difficulty"] = farmer_response.current_difficulty
                                     pool_state["current_points"] = farmer_response.current_points
-                                    pool_state["next_farmer_update"] = time.time() + pool_farmer_info_update_interval
+                                    pool_state["next_farmer_update"] = time.time() + self.pool_farmer_info_update_interval
                             else:
                                 farmer_known = response["error_code"] != PoolErrorCode.FARMER_NOT_KNOWN.value
                                 self.log.error(

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -94,20 +94,6 @@ class Farmer:
         consensus_constants: ConsensusConstants,
         local_keychain: Optional[Keychain] = None,
     ):
-        pool_info_update_interval = UPDATE_POOL_INFO_INTERVAL
-        pool_farmer_info_update_interval = UPDATE_POOL_FARMER_INFO_INTERVAL
-        harvester_cache_update_interval = UPDATE_HARVESTER_CACHE_INTERVAL
-
-        if "update_intervals" in self.config:
-            update_intervals = self.config["update_intervals"]
-
-            if "pool_info" in update_intervals:
-                pool_info_update_interval = update_intervals["pool_info"]
-            if "pool_farmer_info" in update_intervals:
-                pool_farmer_info_update_interval = update_intervals["pool_farmer_info"]
-            if "harvester_cache" in update_intervals:
-                harvester_cache_update_interval = update_intervals["harvester_cache"]
-
         self.keychain_proxy: Optional[KeychainProxy] = None
         self.local_keychain = local_keychain
         self._root_path = root_path
@@ -129,8 +115,22 @@ class Farmer:
         # to periodically clear the memory
         self.cache_add_time: Dict[bytes32, uint64] = {}
 
+        self.pool_info_update_interval = UPDATE_POOL_INFO_INTERVAL
+        self.pool_farmer_info_update_interval = UPDATE_POOL_FARMER_INFO_INTERVAL
+        self.harvester_cache_update_interval = UPDATE_HARVESTER_CACHE_INTERVAL
+
+        if "update_intervals" in self.config:
+            update_intervals = self.config["update_intervals"]
+
+            if "pool_info" in update_intervals:
+                self.pool_info_update_interval = update_intervals["pool_info"]
+            if "pool_farmer_info" in update_intervals:
+                self.pool_farmer_info_update_interval = update_intervals["pool_farmer_info"]
+            if "harvester_cache" in update_intervals:
+                self.harvester_cache_update_interval = update_intervals["harvester_cache"]
+
         # Interval to request plots from connected harvesters
-        self.update_harvester_cache_interval = harvester_cache_update_interval
+        self.update_harvester_cache_interval = self.harvester_cache_update_interval
 
         self.cache_clear_task: asyncio.Task
         self.update_pool_state_task: asyncio.Task

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1682,7 +1682,7 @@ class FullNode:
                 f"Added unfinished_block {block_hash}, not farmed by us,"
                 f" SP: {block.reward_chain_block.signage_point_index} farmer response time: "
                 f"{receive_time - self.signage_point_times[block.reward_chain_block.signage_point_index]:0.4f}, "
-                f"Pool pk {encode_puzzle_hash(block.foliage.foliage_block_data.pool_target.puzzle_hash, 'xch')}, "
+                f"Pool pk {encode_puzzle_hash(block.foliage.foliage_block_data.pool_target.puzzle_hash, 'sit')}, "
                 f"validation time: {validation_time:0.4f} seconds, {pre_validation_log}"
                 f"cost: {block.transactions_info.cost if block.transactions_info else 'None'}"
                 f"{percent_full_str}"

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -86,7 +86,7 @@ class MempoolManager:
         self.lock = asyncio.Lock()
 
         # The fee per cost must be above this amount to consider the fee "nonzero", and thus able to kick out other
-        # transactions. This prevents spam. This is equivalent to 0.055 XCH per block, or about 0.00005 XCH for two
+        # transactions. This prevents spam. This is equivalent to 0.055 SIT per block, or about 0.00005 SIT for two
         # spends.
         self.nonzero_fee_minimum_fpc = 5
 
@@ -190,7 +190,7 @@ class MempoolManager:
 
     @staticmethod
     def get_min_fee_increase() -> int:
-        # 0.00001 XCH
+        # 0.00001 SIT
         return 10000000
 
     def can_replace(

--- a/chia/server/upnp.py
+++ b/chia/server/upnp.py
@@ -33,7 +33,7 @@ class UPnP:
                             self.upnp.deleteportmapping(port, "TCP")
                         except Exception as e:
                             log.info(f"Removal of previous portmapping failed. This does not indicate an error: {e}")
-                        self.upnp.addportmapping(port, "TCP", self.upnp.lanaddr, port, "silicoin", "")
+                        self.upnp.addportmapping(port, "TCP", self.upnp.lanaddr, port, "sit", "")
                         log.info(
                             f"Port {port} opened with UPnP. lanaddr {self.upnp.lanaddr} "
                             f"external: {self.upnp.externalipaddress()}"

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -152,6 +152,12 @@ farmer:
     public_crt:  "config/ssl/farmer/public_farmer.crt"
     public_key:  "config/ssl/farmer/public_farmer.key"
 
+  update_intervals:
+    pool_info: 3600
+    # Some larger farmers have reported better performance when setting both of the values below to 1000.
+    pool_farmer_info: 300
+    harvester_cache: 90
+
 # Don't run this unless you want to run VDF clients on the local machine.
 timelord_launcher:
   # The server where the VDF clients will connect to.

--- a/chia/wallet/puzzles/prefarm/make_prefarm_ph.py
+++ b/chia/wallet/puzzles/prefarm/make_prefarm_ph.py
@@ -30,7 +30,7 @@ def make_puzzle(amount: int) -> int:
     puzzle_hash = puzzle_prog.get_tree_hash()
 
     solution = "()"
-    prefix = "xch"
+    prefix = "sit"
     print("PH", puzzle_hash)
     print(f"Address: {encode_puzzle_hash(puzzle_hash, prefix)}")
 

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -269,7 +269,7 @@ class BlockTools:
             if pool_contract_puzzle_hash is None:
                 pool_pk = self.pool_pk
             else:
-                pool_address = encode_puzzle_hash(pool_contract_puzzle_hash, "xch")
+                pool_address = encode_puzzle_hash(pool_contract_puzzle_hash, "sit")
 
             keys = PlotKeys(self.farmer_pk, pool_pk, pool_address)
             # No datetime in the filename, to get deterministic filenames and not re-plot

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -430,7 +430,7 @@ class TestPoolWalletRpc:
         assert len(await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(2)) == 0
 
         tr: TransactionRecord = await client.send_transaction(
-            1, 100, encode_puzzle_hash(status.p2_singleton_puzzle_hash, "txch")
+            1, 100, encode_puzzle_hash(status.p2_singleton_puzzle_hash, "tsit")
         )
         await time_out_assert(
             10,
@@ -458,7 +458,7 @@ class TestPoolWalletRpc:
         for summary in summaries_response:
             if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
                 assert False
-        # Balance stars at 6 XCH
+        # Balance stars at 6 SIT
         assert (await wallet_0.get_confirmed_balance()) == 6000000000000
         creation_tx: TransactionRecord = await client.create_new_pool_wallet(
             our_ph, "http://123.45.67.89", 10, "localhost:5000", "new", "FARMING_TO_POOL", fee
@@ -532,7 +532,7 @@ class TestPoolWalletRpc:
         assert (
             wallet_node_0.wallet_state_manager.get_peak().height == full_node_api.full_node.blockchain.get_peak().height
         )
-        # Balance stars at 6 XCH and 5 more blocks are farmed, total 22 XCH
+        # Balance stars at 6 SIT and 5 more blocks are farmed, total 22 SIT
         assert (await wallet_0.get_confirmed_balance()) == 21999999999999
 
     @pytest.mark.asyncio

--- a/tests/wallet/rl_wallet/test_rl_rpc.py
+++ b/tests/wallet/rl_wallet/test_rl_rpc.py
@@ -139,7 +139,7 @@ class TestRLWallet:
         assert await wallet.get_confirmed_balance() == fund_owners_initial_balance - 101
         assert await check_balance(api_user, user_wallet_id) == 100
         receiving_wallet = wallet_node_2.wallet_state_manager.main_wallet
-        address = encode_puzzle_hash(await receiving_wallet.get_new_puzzlehash(), "xch")
+        address = encode_puzzle_hash(await receiving_wallet.get_new_puzzlehash(), "sit")
         assert await receiving_wallet.get_spendable_balance() == 0
         val = await api_user.send_transaction({"wallet_id": user_wallet_id, "amount": 3, "fee": 2, "address": address})
         await asyncio.sleep(2)
@@ -160,7 +160,7 @@ class TestRLWallet:
         await time_out_assert(15, wallet_height_at_least, True, wallet_node, 68)
         assert await check_balance(api_user, user_wallet_id) == 195
         # test spending
-        puzzle_hash = encode_puzzle_hash(await receiving_wallet.get_new_puzzlehash(), "xch")
+        puzzle_hash = encode_puzzle_hash(await receiving_wallet.get_new_puzzlehash(), "sit")
         val = await api_user.send_transaction(
             {"wallet_id": user_wallet_id, "amount": 105, "fee": 0, "address": puzzle_hash}
         )


### PR DESCRIPTION
- Improved Staking Info
  - Faster Execution
    - Counts plots using farmer public key as a dictionary key and converts them to a dictionary key with staking addresses afterwards.
    - Current method used in official repo converts the farmer public key to a staking address for each plot counted, rather than for each key/mnemonic on the farm.
  - More Informative
    - Shows total size of plots for each staking address next to the plot count.
    - Shows the fingerprint for the master key associated with each staking address.
- Configurable Farmer Update Intervals
- Better Staking Factor and ETW Estimates
- Various Name Replacements: XCH => SIT